### PR TITLE
fixing install from pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='textgrid',
       author='Kyler Brown',
       author_email='kylerjbrown@gmail.com',
       license='MIT',
-      py_modules="textgrid",
+      py_modules=["textgrid"],
       entry_points= {
           'console_scripts' : [
               'textgrid2csv = textgrid:textgrid2csv',


### PR DESCRIPTION
When installing from pip, the file `textgrid.py` is not actually installed, because `py_modules` should be a list.
This fixes it.

Test:
```
mkdir test
cd test
python3 -m venv env
source env/bin/activate
pip3 install git+https://github.com/kylerbrown/textgrid#egg=textgrid
python3 -c "import textgrid"
pip3 uninstall textgrid
pip3 install git+https://github.com/adefossez/textgrid#egg=textgrid
python3 -c "import textgrid"
```